### PR TITLE
Add the function that keep current joint's value if it isn't set

### DIFF
--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -222,7 +222,7 @@ public:
       {
         if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
           target_.push_back(motion["joints"][i]);
-        else
+        else if (motion["joints"][i] == "KEEP")
           target_.push_back(KEEP);
       }
     }

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -37,8 +37,6 @@
 
 #pragma once
 
-#define KEEP 999
-
 #include <rm_common/ros_utilities.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/Twist.h>
@@ -224,7 +222,7 @@ public:
         if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
           target_.push_back(motion["joints"][i]);
         else if (motion["joints"][i] == "KEEP")
-          target_.push_back(KEEP);
+          target_.push_back(NAN);
       }
     }
     if (motion.hasMember("tolerance"))
@@ -240,7 +238,7 @@ public:
       return false;
     MoveitMotionBase::move();
     for (long unsigned int i = 0; i < target_.size(); i++)
-      if (target_[i] == KEEP)
+      if (target_[i] == NAN)
         target_[i] = interface_.getCurrentJointValues()[i];
     interface_.setJointValueTarget(target_);
     return (interface_.asyncMove() == moveit::planning_interface::MoveItErrorCode::SUCCESS);

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -217,7 +217,12 @@ public:
     {
       ROS_ASSERT(motion["joints"].getType() == XmlRpc::XmlRpcValue::TypeArray);
       for (int i = 0; i < motion["joints"].size(); ++i)
-        target_.push_back(xmlRpcGetDouble(motion["joints"], i));
+      {
+        if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
+          target_.push_back(motion["joints"][i]);
+        else
+          target_.push_back(999);
+      }
     }
     if (motion.hasMember("tolerance"))
     {
@@ -233,6 +238,9 @@ public:
     if (target_.empty())
       return false;
     MoveitMotionBase::move();
+    for (long unsigned int i = 0; i < target_.size(); i++)
+      if (target_[i] == 999)
+        target_[i] = interface_.getCurrentJointValues()[i];
     interface_.setJointValueTarget(target_);
     return (interface_.asyncMove() == moveit::planning_interface::MoveItErrorCode::SUCCESS);
   }

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -238,7 +238,7 @@ public:
       return false;
     MoveitMotionBase::move();
     for (long unsigned int i = 0; i < target_.size(); i++)
-      if (target_[i] == NAN)
+      if (!std::isnormal(target_[i]))
         target_[i] = interface_.getCurrentJointValues()[i];
     interface_.setJointValueTarget(target_);
     return (interface_.asyncMove() == moveit::planning_interface::MoveItErrorCode::SUCCESS);

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -220,6 +220,7 @@ public:
       ROS_ASSERT(motion["joints"].getType() == XmlRpc::XmlRpcValue::TypeArray);
       for (int i = 0; i < motion["joints"].size(); ++i)
       {
+        ROS_ASSERT(motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble || motion["joints"][i] == "KEEP");
         if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
           target_.push_back(motion["joints"][i]);
         else if (motion["joints"][i] == "KEEP")


### PR DESCRIPTION
为joints的设置添加了新的功能，当在steps中未设置某个位置的值的时候，程序默认为保持当前value位置，随之仅仅改变被修改的joints值，可用于操作手兑换时候调整直臂，或者其他灵活的变化使用