### PR TITLE
Add the topic to know the result of planning

### DIFF
--- a/engineer_middleware/include/engineer_middleware/middleware.h
+++ b/engineer_middleware/include/engineer_middleware/middleware.h
@@ -76,7 +76,7 @@ private:
   actionlib::SimpleActionServer<rm_msgs::EngineerAction> as_;
   moveit::planning_interface::MoveGroupInterface arm_group_;
   ChassisInterface chassis_interface_;
-  ros::Publisher hand_pub_, card_pub_, gimbal_pub_, gpio_pub_;
+  ros::Publisher hand_pub_, card_pub_, gimbal_pub_, gpio_pub_, planning_result_pub_;
   std::unordered_map<std::string, StepQueue> step_queues_;
   tf2_ros::Buffer tf_;
   tf2_ros::TransformListener tf_listener_;

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -106,7 +106,7 @@ public:
     interface_.setMaxAccelerationScalingFactor(0.);
     interface_.stop();
   }
-  std_msgs::Int32 judgePlanningResult()
+  std_msgs::Int32 getPlanningResult()
   {
     return msg_;
   }

--- a/engineer_middleware/include/engineer_middleware/planning_scene.h
+++ b/engineer_middleware/include/engineer_middleware/planning_scene.h
@@ -82,7 +82,10 @@ public:
       collision_objects_[i].operation = collision_objects_[i].ADD;
     planning_scene_interface_.addCollisionObjects(collision_objects_);
     if (is_attached_)
+    {
+      std::cout << planning_scene_interface_.getAttachedObjects().size() << std::endl;
       arm_group_.attachObject(collision_objects_[0].id, collision_objects_[0].header.frame_id);
+    }
   }
 
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -84,7 +84,7 @@ public:
     if (arm_motion_)
     {
       success &= arm_motion_->move();
-      std_msgs::Int32 msg = arm_motion_->judgePlanningResult();
+      std_msgs::Int32 msg = arm_motion_->getPlanningResult();
       planning_result_pub_.publish(msg);
     }
     if (hand_motion_)

--- a/engineer_middleware/include/engineer_middleware/step_queue.h
+++ b/engineer_middleware/include/engineer_middleware/step_queue.h
@@ -53,12 +53,14 @@ class StepQueue
 public:
   StepQueue(const XmlRpc::XmlRpcValue& steps, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
             moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-            ros::Publisher& hand_pub, ros::Publisher& card_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub)
+            ros::Publisher& hand_pub, ros::Publisher& card_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
+            ros::Publisher& planning_result_pub)
     : chassis_interface_(chassis_interface)
   {
     ROS_ASSERT(steps.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < steps.size(); ++i)
-      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, card_pub, gimbal_pub, gpio_pub);
+      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, card_pub, gimbal_pub, gpio_pub,
+                          planning_result_pub);
   }
   bool run(actionlib::SimpleActionServer<rm_msgs::EngineerAction>& as)
   {

--- a/engineer_middleware/src/middleware.cpp
+++ b/engineer_middleware/src/middleware.cpp
@@ -49,6 +49,7 @@ Middleware::Middleware(ros::NodeHandle& nh)
   , card_pub_(nh.advertise<std_msgs::Float64>("/controllers/card_controller/command", 10))
   , gimbal_pub_(nh.advertise<rm_msgs::GimbalCmd>("/controllers/gimbal_controller/command", 10))
   , gpio_pub_(nh.advertise<rm_msgs::GpioData>("/controllers/gpio_controller/command", 10))
+  , planning_result_pub_(nh.advertise<std_msgs::Int32>("/planning_result", 10))
   , tf_listener_(tf_)
   , is_middleware_control_(false)
 {
@@ -64,7 +65,7 @@ Middleware::Middleware(ros::NodeHandle& nh)
     {
       step_queues_.insert(
           std::make_pair(it->first, StepQueue(it->second, scenes_list, tf_, arm_group_, chassis_interface_, hand_pub_,
-                                              card_pub_, gimbal_pub_, gpio_pub_)));
+                                              card_pub_, gimbal_pub_, gpio_pub_, planning_result_pub_)));
     }
   }
   else


### PR DESCRIPTION
修改了让机械臂开始运动的方式，以前是规划和执行同时开始的asyncMove，始终会返回success，无法得知规划的结果；现在更换成了plan+exe的方式，可以通过plan后的结果知道当前规划后的结果然后发送到一个话题中。之后ui会通过这个话题知道当前规划结果，然后可应用于自动兑换操作手得知当前规划的结果，从而更改底盘位置或者采取对应的措施