### PR TITLE
Add stone_num, point_cloud, spaceEEMotion.

### DIFF
--- a/engineer_middleware/config/steps_list.yaml
+++ b/engineer_middleware/config/steps_list.yaml
@@ -155,7 +155,7 @@ common:
     drag_car_position: &JOINT6_DRAG_CAR_POSITION
                          1.631
 
-  joint7:
+  end_effector:
     use_for_delay: &DELAY_0_1
       target: 0.008
       delay: 0.1
@@ -365,11 +365,11 @@ steps_list:
   ################### JOINT7 ####################
   JOINT7_UP:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
   JOINT7_DOWN:
     - step: "joint7 down"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
   ################### GRIPPER ####################
   OPEN_GRIPPER:
@@ -436,7 +436,7 @@ steps_list:
       gimbal:
         <<: *SIDE_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "avoid collision"
       arm:
@@ -453,7 +453,7 @@ steps_list:
       gimbal:
         <<: *SIDE_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "home with one stone"
       arm:
@@ -463,7 +463,7 @@ steps_list:
       gimbal:
         <<: *SIDE_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "home with two stone"
       arm:
@@ -473,7 +473,7 @@ steps_list:
       gimbal:
         <<: *SIDE_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "home with three stone"
       arm:
@@ -506,7 +506,7 @@ steps_list:
         tolerance:
           <<: *BIGGER_TOLERANCE
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_POSITION
   GROUND_STONE00:
     - step: "change gripper state"
@@ -535,7 +535,7 @@ steps_list:
         tolerance:
           <<: *BIGGER_TOLERANCE
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "move joint2"
       arm:
@@ -589,16 +589,16 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_LESS_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_MORE_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "move to exchange wait state"
       arm:
@@ -666,7 +666,7 @@ steps_list:
       gripper:
         <<: *OPEN_GRIPPER
     - step: "joint7 down"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "move to exchange wait state"
       arm:
@@ -684,7 +684,7 @@ steps_list:
         tolerance:
           <<: *BIGGER_TOLERANCE
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint6"
       arm:
@@ -719,7 +719,7 @@ steps_list:
   ###################    SMALL_ISLAND    ####################
   LF_SMALL_ISLAND0:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "island gimbal"
       gimbal:
@@ -787,7 +787,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "change gripper state"
       gripper:
@@ -811,7 +811,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -855,7 +855,7 @@ steps_list:
     ###################    MID    ################
   SMALL_ISLAND:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "arm wait"
       arm:
@@ -922,7 +922,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "arm ready to get stone"
       arm:
@@ -951,7 +951,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -993,7 +993,7 @@ steps_list:
     ###################    RT    ################
   RT_SMALL_ISLAND0:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "island gimbal"
       gimbal:
@@ -1062,7 +1062,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "change gripper state"
       gripper:
@@ -1086,7 +1086,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1128,7 +1128,7 @@ steps_list:
       ###################    STORE    ####################
   STORE_WHEN_ZERO_STONE0:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "open gripper"
       gripper:
@@ -1172,7 +1172,7 @@ steps_list:
 
   STORE_WHEN_ONE_STONE0:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "open gripper"
       gripper:
@@ -1223,7 +1223,7 @@ steps_list:
 
   STORE_WHEN_TWO_STONE0:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "open gripper"
       gripper:
@@ -1271,7 +1271,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "avoid collision"
       arm:
@@ -1324,16 +1324,16 @@ steps_list:
       stone_num:
         change: "-1"
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_LESS_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_MORE_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "move to exchange wait state"
       arm:
@@ -1348,7 +1348,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "avoid collision"
       arm:
@@ -1375,7 +1375,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "DELAY 0.1"
-      joint7:
+      end_effector:
         <<: *DELAY_0_1
     - step: "REVERSAL OUT"
       reversal:
@@ -1394,16 +1394,16 @@ steps_list:
       stone_num:
         change: "-1"
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_LESS_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_MORE_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "move to exchange wait state"
       arm:
@@ -1418,7 +1418,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "avoid collision"
       arm:
@@ -1445,7 +1445,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "DELAY 0.1"
-      joint7:
+      end_effector:
         <<: *DELAY_0_1
     - step: "move joint2 to get stone"
       arm:
@@ -1471,16 +1471,16 @@ steps_list:
       stone_num:
         change: "-1"
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_LESS_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_MID_MORE_NO_DELAY_POSITION
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "move to exchange wait state"
       arm:
@@ -1500,7 +1500,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "arm ready to get stone"
       arm:
@@ -1529,7 +1529,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1572,7 +1572,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_POSITION
     - step: "change gripper state"
       gripper:
@@ -1599,7 +1599,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1642,7 +1642,7 @@ steps_list:
         tolerance:
           <<: *BIGGER_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_POSITION
     - step: "change gripper state"
       gripper:
@@ -1679,7 +1679,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1723,7 +1723,7 @@ steps_list:
       gimbal:
         <<: *ISLAND_POS
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_NO_DELAY_POSITION
     - step: "arm ready to get stone"
       arm:
@@ -1752,7 +1752,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1798,7 +1798,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_DOWN_POSITION
     - step: "change gripper state"
       gripper:
@@ -1829,7 +1829,7 @@ steps_list:
         tolerance:
           <<: *NORMAL_TOLERANCE
     - step: "joint7"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_POSITION
     - step: "move joint1 and 3"
       arm:
@@ -1883,7 +1883,7 @@ steps_list:
         <<: *SIDE_POS
   THREE_STONE_SMALL_ISLAND:
     - step: "joint7 up"
-      joint7:
+      end_effector:
         <<: *JOINT7_UP_NO_DELAY_POSITION
     - step: "arm wait"
       arm:

--- a/engineer_middleware/include/engineer_middleware/middleware.h
+++ b/engineer_middleware/include/engineer_middleware/middleware.h
@@ -81,15 +81,11 @@ private:
   actionlib::SimpleActionServer<rm_msgs::EngineerAction> as_;
   moveit::planning_interface::MoveGroupInterface arm_group_;
   ChassisInterface chassis_interface_;
-  geometry_msgs::TwistStamped position_;
-  geometry_msgs::TwistStamped test_;
   ros::Publisher hand_pub_, joint7_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, planning_result_pub_, stone_num_pub_,
       point_cloud_pub_;
   std::unordered_map<std::string, StepQueue> step_queues_;
   tf2_ros::Buffer tf_;
   tf2_ros::TransformListener tf_listener_;
-  tf::TransformBroadcaster br_;
-  tf::Transform transform;
   bool is_middleware_control_;
 };
 

--- a/engineer_middleware/include/engineer_middleware/middleware.h
+++ b/engineer_middleware/include/engineer_middleware/middleware.h
@@ -46,6 +46,11 @@
 #include <controller_manager_msgs/SwitchController.h>
 #include <rm_msgs/EngineerAction.h>
 #include <rm_msgs/GpioData.h>
+#include <tf/transform_broadcaster.h>
+#include <tf/tf.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 namespace engineer_middleware
 {
@@ -76,10 +81,15 @@ private:
   actionlib::SimpleActionServer<rm_msgs::EngineerAction> as_;
   moveit::planning_interface::MoveGroupInterface arm_group_;
   ChassisInterface chassis_interface_;
-  ros::Publisher hand_pub_, card_pub_, gimbal_pub_, gpio_pub_, planning_result_pub_;
+  geometry_msgs::TwistStamped position_;
+  geometry_msgs::TwistStamped test_;
+  ros::Publisher hand_pub_, joint7_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, planning_result_pub_, stone_num_pub_,
+      point_cloud_pub_;
   std::unordered_map<std::string, StepQueue> step_queues_;
   tf2_ros::Buffer tf_;
   tf2_ros::TransformListener tf_listener_;
+  tf::TransformBroadcaster br_;
+  tf::Transform transform;
   bool is_middleware_control_;
 };
 

--- a/engineer_middleware/include/engineer_middleware/middleware.h
+++ b/engineer_middleware/include/engineer_middleware/middleware.h
@@ -81,8 +81,8 @@ private:
   actionlib::SimpleActionServer<rm_msgs::EngineerAction> as_;
   moveit::planning_interface::MoveGroupInterface arm_group_;
   ChassisInterface chassis_interface_;
-  ros::Publisher hand_pub_, joint7_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, planning_result_pub_, stone_num_pub_,
-      point_cloud_pub_;
+  ros::Publisher hand_pub_, end_effector_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, planning_result_pub_,
+      stone_num_pub_, point_cloud_pub_;
   std::unordered_map<std::string, StepQueue> step_queues_;
   tf2_ros::Buffer tf_;
   tf2_ros::TransformListener tf_listener_;

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -136,14 +136,14 @@ public:
     target_.pose.orientation.w = 1.;
     tolerance_position_ = xmlRpcGetDouble(motion, "tolerance_position", 0.01);
     tolerance_orientation_ = xmlRpcGetDouble(motion, "tolerance_orientation", 0.1);
-    if (motion.hasMember("frame"))
-      target_.header.frame_id = std::string(motion["frame"]);
-    if (motion.hasMember("position"))
+    ROS_ASSERT(motion.hasMember("frame"));
+    target_.header.frame_id = std::string(motion["frame"]);
+    if (motion.hasMember("xyz"))
     {
-      ROS_ASSERT(motion["position"].getType() == XmlRpc::XmlRpcValue::TypeArray);
-      target_.pose.position.x = xmlRpcGetDouble(motion["position"], 0);
-      target_.pose.position.y = xmlRpcGetDouble(motion["position"], 1);
-      target_.pose.position.z = xmlRpcGetDouble(motion["position"], 2);
+      ROS_ASSERT(motion["xyz"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      target_.pose.position.x = xmlRpcGetDouble(motion["xyz"], 0);
+      target_.pose.position.y = xmlRpcGetDouble(motion["xyz"], 1);
+      target_.pose.position.z = xmlRpcGetDouble(motion["xyz"], 2);
       has_pos_ = true;
     }
     if (motion.hasMember("rpy"))
@@ -237,14 +237,14 @@ public:
                 tf2_ros::Buffer& tf)
     : EndEffectorMotion(motion, interface, tf), tf_(tf)
   {
-    if (motion.hasMember("frame"))
-      target_.header.frame_id = std::string(motion["frame"]);
-    if (motion.hasMember("position"))
+    ROS_ASSERT(motion.hasMember("frame"));
+    target_.header.frame_id = std::string(motion["frame"]);
+    if (motion.hasMember("xyz"))
     {
-      ROS_ASSERT(motion["position"].getType() == XmlRpc::XmlRpcValue::TypeArray);
-      target_.pose.position.x = xmlRpcGetDouble(motion["position"], 0);
-      target_.pose.position.y = xmlRpcGetDouble(motion["position"], 1);
-      target_.pose.position.z = xmlRpcGetDouble(motion["position"], 2);
+      ROS_ASSERT(motion["xyz"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      target_.pose.position.x = xmlRpcGetDouble(motion["xyz"], 0);
+      target_.pose.position.y = xmlRpcGetDouble(motion["xyz"], 1);
+      target_.pose.position.z = xmlRpcGetDouble(motion["xyz"], 2);
     }
     if (motion.hasMember("rpy"))
     {
@@ -255,11 +255,12 @@ public:
       target_.pose.orientation = quat_msg;
     }
     radius_ = xmlRpcGetDouble(motion, "radius", 0.1);
-    if (motion.hasMember("xyz"))
+    if (motion.hasMember("basics_length"))
     {
-      x_length_ = xmlRpcGetDouble(motion["xyz"], 0);
-      y_length_ = xmlRpcGetDouble(motion["xyz"], 1);
-      z_length_ = xmlRpcGetDouble(motion["xyz"], 2);
+      ROS_ASSERT(motion["basics_length"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      x_length_ = xmlRpcGetDouble(motion["basics_length"], 0);
+      y_length_ = xmlRpcGetDouble(motion["basics_length"], 1);
+      z_length_ = xmlRpcGetDouble(motion["basics_length"], 2);
     }
     if (motion.hasMember("rpy_rectify"))
     {

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -109,7 +109,7 @@ public:
     interface_.setMaxAccelerationScalingFactor(0.);
     interface_.stop();
   }
-  std_msgs::Int32 judgePlanningResult()
+  std_msgs::Int32 getPlanningResult()
   {
     return msg_;
   }
@@ -325,9 +325,10 @@ public:
       ROS_ASSERT(motion["joints"].getType() == XmlRpc::XmlRpcValue::TypeArray);
       for (int i = 0; i < motion["joints"].size(); ++i)
       {
+        ROS_ASSERT(motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble || motion["joints"][i] == "KEEP");
         if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
           target_.push_back(motion["joints"][i]);
-        else
+        else if (motion["joints"][i] == "KEEP")
           target_.push_back(NAN);
       }
     }

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -183,8 +183,12 @@ public:
       moveit_msgs::RobotTrajectory trajectory;
       std::vector<geometry_msgs::Pose> waypoints;
       waypoints.push_back(target_.pose);
-      if (interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) < 99.9)
+      if (interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) != 1)
+      {
+        ROS_INFO_STREAM("Collisions will occur in the"
+                        << interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) << "of the trajectory");
         return false;
+      }
       return interface_.asyncExecute(trajectory) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
     }
     else

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -44,8 +44,11 @@
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <rm_msgs/GimbalCmd.h>
 #include <rm_msgs/GpioData.h>
+#include <rm_msgs/MultiDofCmd.h>
 #include <std_msgs/Int32.h>
+#include <std_msgs/String.h>
 #include <engineer_middleware/chassis_interface.h>
+#include <engineer_middleware/points.h>
 
 namespace engineer_middleware
 {
@@ -106,9 +109,13 @@ public:
     interface_.setMaxAccelerationScalingFactor(0.);
     interface_.stop();
   }
-  std_msgs::Int32 getPlanningResult()
+  std_msgs::Int32 judgePlanningResult()
   {
     return msg_;
+  }
+  sensor_msgs::PointCloud2 getPointCloud2()
+  {
+    return points_.getPointCloud2();
   }
 
 protected:
@@ -116,6 +123,7 @@ protected:
   double speed_, accel_;
   int countdown_{};
   std_msgs::Int32 msg_;
+  Points points_;
 };
 
 class EndEffectorMotion : public MoveitMotionBase
@@ -151,11 +159,12 @@ public:
     if (motion.hasMember("cartesian"))
       is_cartesian_ = motion["cartesian"];
   }
+
   bool move() override
   {
     MoveitMotionBase::move();
     geometry_msgs::PoseStamped final_target;
-    if (!target_.header.frame_id.empty() && target_.header.frame_id != interface_.getPlanningFrame())
+    if (!target_.header.frame_id.empty())
     {
       try
       {
@@ -174,12 +183,8 @@ public:
       moveit_msgs::RobotTrajectory trajectory;
       std::vector<geometry_msgs::Pose> waypoints;
       waypoints.push_back(target_.pose);
-      if (interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) != 1)
-      {
-        ROS_INFO_STREAM("Collisions will occur in the"
-                        << interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) << "of the trajectory");
+      if (interface_.computeCartesianPath(waypoints, 0.01, 0.0, trajectory) < 99.9)
         return false;
-      }
       return interface_.asyncExecute(trajectory) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
     }
     else
@@ -221,6 +226,107 @@ private:
   double tolerance_position_, tolerance_orientation_;
 };
 
+class SpaceEEMotion : public EndEffectorMotion
+{
+public:
+  SpaceEEMotion(XmlRpc::XmlRpcValue& motion, moveit::planning_interface::MoveGroupInterface& interface,
+                tf2_ros::Buffer& tf)
+    : EndEffectorMotion(motion, interface, tf), tf_(tf)
+  {
+    if (motion.hasMember("frame"))
+      target_.header.frame_id = std::string(motion["frame"]);
+    if (motion.hasMember("position"))
+    {
+      ROS_ASSERT(motion["position"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      target_.pose.position.x = xmlRpcGetDouble(motion["position"], 0);
+      target_.pose.position.y = xmlRpcGetDouble(motion["position"], 1);
+      target_.pose.position.z = xmlRpcGetDouble(motion["position"], 2);
+    }
+    if (motion.hasMember("rpy"))
+    {
+      ROS_ASSERT(motion["rpy"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      tf2::Quaternion quat_tf;
+      quat_tf.setRPY(motion["rpy"][0], motion["rpy"][1], motion["rpy"][2]);
+      geometry_msgs::Quaternion quat_msg = tf2::toMsg(quat_tf);
+      target_.pose.orientation = quat_msg;
+    }
+    radius_ = xmlRpcGetDouble(motion, "radius", 0.1);
+    if (motion.hasMember("xyz"))
+    {
+      x_length_ = xmlRpcGetDouble(motion["xyz"], 0);
+      y_length_ = xmlRpcGetDouble(motion["xyz"], 1);
+      z_length_ = xmlRpcGetDouble(motion["xyz"], 2);
+    }
+    if (motion.hasMember("rpy_rectify"))
+    {
+      k_x_ = xmlRpcGetDouble(motion["rpy_rectify"], 0);
+      k_theta_ = xmlRpcGetDouble(motion["rpy_rectify"], 1);
+      k_beta_ = xmlRpcGetDouble(motion["rpy_rectify"], 2);
+    }
+    point_resolution_ = xmlRpcGetDouble(motion, "point_resolution", 0.01);
+    max_planning_times_ = (int)xmlRpcGetDouble(motion, "max_planning_times", 100);
+    if (motion.hasMember("spacial_shape"))
+    {
+      points_.cleanPoints();
+      if (motion["spacial_shape"] == "SPHERE")
+        points_.setValue(Points::SPHERE, target_.pose.position.x, target_.pose.position.y, target_.pose.position.z,
+                         radius_, point_resolution_);
+      else if (motion["spacial_shape"] == "BASICS")
+        points_.setValue(Points::BASICS, target_.pose.position.x, target_.pose.position.y, target_.pose.position.z,
+                         x_length_, y_length_, z_length_, point_resolution_);
+      else
+        ROS_ERROR("NO");
+      points_.generateGeometryPoints();
+    }
+  }
+  bool move() override
+  {
+    points_.cleanPoints();
+    points_.generateGeometryPoints();
+    MoveitMotionBase::move();
+    int move_times = (int)points_.getPoints().size();
+    for (int i = 0; i < move_times && i < max_planning_times_; ++i)
+    {
+      geometry_msgs::PoseStamped final_target;
+      if (!target_.header.frame_id.empty())
+      {
+        try
+        {
+          tf2::doTransform(target_.pose, final_target.pose,
+                           tf_.lookupTransform(interface_.getPlanningFrame(), target_.header.frame_id, ros::Time(0)));
+          final_target.header.frame_id = interface_.getPlanningFrame();
+          exchange2base_ = tf_.lookupTransform("base_link", target_.header.frame_id, ros::Time(0));
+          double roll, pitch, yaw;
+          quatToRPY(exchange2base_.transform.rotation, roll, pitch, yaw);
+          points_.rectifyForRPY(pitch, yaw, k_x_, k_theta_, k_beta_);
+        }
+        catch (tf2::TransformException& ex)
+        {
+          ROS_WARN("%s", ex.what());
+          return false;
+        }
+      }
+      target_.pose.position.x = points_.getPoints()[i].x;
+      target_.pose.position.y = points_.getPoints()[i].y;
+      target_.pose.position.z = points_.getPoints()[i].z;
+      interface_.setPoseTarget(final_target);
+      moveit::planning_interface::MoveGroupInterface::Plan plan;
+      msg_.data = interface_.plan(plan).val;
+      if (msg_.data == 1)
+        return interface_.asyncExecute(plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
+    }
+    return false;
+  }
+
+private:
+  tf2_ros::Buffer& tf_;
+  geometry_msgs::PoseStamped target_;
+  geometry_msgs::TransformStamped exchange2base_;
+  int max_planning_times_{};
+  bool is_moved_{ false };
+  double radius_, point_resolution_, x_length_, y_length_, z_length_, k_theta_, k_beta_, k_x_;
+};
+
 class JointMotion : public MoveitMotionBase
 {
 public:
@@ -232,10 +338,9 @@ public:
       ROS_ASSERT(motion["joints"].getType() == XmlRpc::XmlRpcValue::TypeArray);
       for (int i = 0; i < motion["joints"].size(); ++i)
       {
-        ROS_ASSERT(motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble || motion["joints"][i] == "KEEP");
         if (motion["joints"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
           target_.push_back(motion["joints"][i]);
-        else if (motion["joints"][i] == "KEEP")
+        else
           target_.push_back(NAN);
       }
     }
@@ -248,17 +353,23 @@ public:
   }
   bool move() override
   {
+    final_target_.clear();
     if (target_.empty())
       return false;
     MoveitMotionBase::move();
-    std::vector<double> final_target = target_;
-    for (long unsigned int i = 0; i < target_.size(); i++)
+    for (int i = 0; i < (int)target_.size(); i++)
+    {
       if (!std::isnormal(target_[i]))
-        final_target[i] = interface_.getCurrentJointValues()[i];
-    interface_.setJointValueTarget(final_target);
+      {
+        final_target_.push_back(interface_.getCurrentJointValues()[i]);
+      }
+      else
+        final_target_.push_back(target_[i]);
+    }
+    interface_.setJointValueTarget(final_target_);
     moveit::planning_interface::MoveGroupInterface::Plan plan;
     msg_.data = interface_.plan(plan).val;
-    return interface_.asyncExecute(plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
+    return (interface_.asyncExecute(plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS);
   }
 
 private:
@@ -267,14 +378,14 @@ private:
     std::vector<double> current = interface_.getCurrentJointValues();
     double error = 0.;
     bool flag = 1;
-    for (int i = 0; i < (int)target_.size(); ++i)
+    for (int i = 0; i < (int)final_target_.size(); ++i)
     {
-      error = std::abs(target_[i] - current[i]);
+      error = std::abs(final_target_[i] - current[i]);
       flag &= (error < tolerance_joints_[i]);
     }
     return flag;
   }
-  std::vector<double> target_, tolerance_joints_;
+  std::vector<double> target_, final_target_, tolerance_joints_;
 };
 
 template <class MsgType>
@@ -348,6 +459,16 @@ private:
   bool state_;
 };
 
+class StoneNumMotion : public PublishMotion<std_msgs::String>
+{
+public:
+  StoneNumMotion(XmlRpc::XmlRpcValue& motion, ros::Publisher& interface)
+    : PublishMotion<std_msgs::String>(motion, interface)
+  {
+    msg_.data = static_cast<std::string>(motion["change"]);
+  }
+};
+
 class JointPositionMotion : public PublishMotion<std_msgs::Float64>
 {
 public:
@@ -355,8 +476,24 @@ public:
     : PublishMotion<std_msgs::Float64>(motion, interface)
   {
     ROS_ASSERT(motion.hasMember("target"));
-    msg_.data = xmlRpcGetDouble(motion, "target", 0.0);
+    ROS_ASSERT(motion.hasMember("delay"));
+    target_ = xmlRpcGetDouble(motion, "target", 0.0);
+    delay_ = xmlRpcGetDouble(motion, "delay", 0.0);
   }
+  bool move() override
+  {
+    start_time_ = ros::Time::now();
+    msg_.data = target_;
+    return PublishMotion::move();
+  }
+  bool isFinish() override
+  {
+    return ((ros::Time::now() - start_time_).toSec() > delay_);
+  }
+
+private:
+  double target_, delay_;
+  ros::Time start_time_;
 };
 
 class GimbalMotion : public PublishMotion<rm_msgs::GimbalCmd>
@@ -421,4 +558,60 @@ private:
   double chassis_tolerance_position_, chassis_tolerance_angular_;
 };
 
-}  // namespace engineer_middleware
+class ReversalMotion : public PublishMotion<rm_msgs::MultiDofCmd>
+{
+public:
+  ReversalMotion(XmlRpc::XmlRpcValue& motion, ros::Publisher& interface)
+    : PublishMotion<rm_msgs::MultiDofCmd>(motion, interface)
+  {
+    delay_ = xmlRpcGetDouble(motion, "delay", 0.0);
+    if (std::string(motion["mode"]) == "POSITION")
+      msg_.mode = msg_.POSITION;
+    else
+      msg_.mode = msg_.VELOCITY;
+    if (motion.hasMember("values"))
+    {
+      ROS_ASSERT(motion["values"].getType() == XmlRpc::XmlRpcValue::TypeArray);
+      msg_.linear.x = xmlRpcGetDouble(motion["values"], 0);
+      msg_.linear.y = xmlRpcGetDouble(motion["values"], 1);
+      msg_.linear.z = xmlRpcGetDouble(motion["values"], 2);
+      msg_.angular.x = xmlRpcGetDouble(motion["values"], 3);
+      msg_.angular.y = xmlRpcGetDouble(motion["values"], 4);
+      msg_.angular.z = xmlRpcGetDouble(motion["values"], 5);
+    }
+  }
+  void setZero()
+  {
+    zero_msg_.mode = msg_.mode;
+    zero_msg_.linear.x = 0.;
+    zero_msg_.linear.y = 0.;
+    zero_msg_.linear.z = 0.;
+    zero_msg_.angular.x = 0.;
+    zero_msg_.angular.y = 0.;
+    zero_msg_.angular.z = 0.;
+  }
+  bool move() override
+  {
+    start_time_ = ros::Time::now();
+    interface_.publish(msg_);
+    if (msg_.mode == msg_.POSITION)
+    {
+      t.sleep();
+      ReversalMotion::setZero();
+      interface_.publish(zero_msg_);
+    }
+    return true;
+  }
+  bool isFinish() override
+  {
+    return ((ros::Time::now() - start_time_).toSec() > delay_);
+  }
+
+private:
+  double delay_;
+  ros::Duration t = ros::Duration(0.2);
+  ros::Time start_time_;
+  rm_msgs::MultiDofCmd zero_msg_;
+};
+
+};  // namespace engineer_middleware

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -584,7 +584,7 @@ public:
     interface_.publish(msg_);
     if (msg_.mode == msg_.POSITION)
     {
-      t.sleep();
+      ros::Duration(0.2).sleep();
       ReversalMotion::setZero();
       interface_.publish(zero_msg_);
     }
@@ -597,7 +597,6 @@ public:
 
 private:
   double delay_;
-  ros::Duration t = ros::Duration(0.2);
   ros::Time start_time_;
   rm_msgs::MultiDofCmd zero_msg_;
 };

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -237,23 +237,6 @@ public:
                 tf2_ros::Buffer& tf)
     : EndEffectorMotion(motion, interface, tf), tf_(tf)
   {
-    ROS_ASSERT(motion.hasMember("frame"));
-    target_.header.frame_id = std::string(motion["frame"]);
-    if (motion.hasMember("xyz"))
-    {
-      ROS_ASSERT(motion["xyz"].getType() == XmlRpc::XmlRpcValue::TypeArray);
-      target_.pose.position.x = xmlRpcGetDouble(motion["xyz"], 0);
-      target_.pose.position.y = xmlRpcGetDouble(motion["xyz"], 1);
-      target_.pose.position.z = xmlRpcGetDouble(motion["xyz"], 2);
-    }
-    if (motion.hasMember("rpy"))
-    {
-      ROS_ASSERT(motion["rpy"].getType() == XmlRpc::XmlRpcValue::TypeArray);
-      tf2::Quaternion quat_tf;
-      quat_tf.setRPY(motion["rpy"][0], motion["rpy"][1], motion["rpy"][2]);
-      geometry_msgs::Quaternion quat_msg = tf2::toMsg(quat_tf);
-      target_.pose.orientation = quat_msg;
-    }
     radius_ = xmlRpcGetDouble(motion, "radius", 0.1);
     if (motion.hasMember("basics_length"))
     {
@@ -328,7 +311,6 @@ private:
   geometry_msgs::PoseStamped target_;
   geometry_msgs::TransformStamped exchange2base_;
   int max_planning_times_{};
-  bool is_moved_{ false };
   double radius_, point_resolution_, x_length_, y_length_, z_length_, k_theta_, k_beta_, k_x_;
 };
 

--- a/engineer_middleware/include/engineer_middleware/planning_scene.h
+++ b/engineer_middleware/include/engineer_middleware/planning_scene.h
@@ -82,7 +82,10 @@ public:
       collision_objects_[i].operation = collision_objects_[i].ADD;
     planning_scene_interface_.addCollisionObjects(collision_objects_);
     if (is_attached_)
+    {
+      std::cout << planning_scene_interface_.getAttachedObjects().size() << std::endl;
       arm_group_.attachObject(collision_objects_[0].id, collision_objects_[0].header.frame_id);
+    }
   }
 
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;

--- a/engineer_middleware/include/engineer_middleware/planning_scene.h
+++ b/engineer_middleware/include/engineer_middleware/planning_scene.h
@@ -82,10 +82,7 @@ public:
       collision_objects_[i].operation = collision_objects_[i].ADD;
     planning_scene_interface_.addCollisionObjects(collision_objects_);
     if (is_attached_)
-    {
-      std::cout << planning_scene_interface_.getAttachedObjects().size() << std::endl;
       arm_group_.attachObject(collision_objects_[0].id, collision_objects_[0].header.frame_id);
-    }
   }
 
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;

--- a/engineer_middleware/include/engineer_middleware/points.h
+++ b/engineer_middleware/include/engineer_middleware/points.h
@@ -74,7 +74,6 @@ public:
       cloud.points[i].x = points_final_[i].x;
       cloud.points[i].y = points_final_[i].y;
       cloud.points[i].z = points_final_[i].z;
-      // cloud.channels[0].values[i] = i;
     }
     sensor_msgs::convertPointCloudToPointCloud2(cloud, cloud2);
     return cloud2;

--- a/engineer_middleware/include/engineer_middleware/points.h
+++ b/engineer_middleware/include/engineer_middleware/points.h
@@ -1,0 +1,171 @@
+//
+// Created by lsy on 23-5-9.
+//
+
+#pragma once
+
+#include <algorithm>
+#include <sensor_msgs/PointCloud.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/point_cloud_conversion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+namespace engineer_middleware
+{
+class Points
+{
+public:
+  Points() = default;
+  ~Points() = default;
+  struct Point
+  {
+    double x, y, z, distance;
+    static bool comparePointsDistance(const Point& a, const Point& b)
+    {
+      return a.distance < b.distance;
+    }
+  };
+  enum Geometry
+  {
+    SPHERE,
+    BASICS
+  };
+
+  void generateSpherePoints(double center_x, double center_y, double center_z, double r, double point_resolution)
+  {
+    points_final_.clear();
+    std::vector<Point> points;
+    double angular_resolution = 2 * M_PI * (1 - point_resolution);
+
+    for (double r_temp = 0.001; r_temp <= r; r_temp += r * (1 - point_resolution))
+    {
+      for (double phi = -M_PI; phi <= M_PI; phi += angular_resolution)
+      {
+        for (double theta = 0.; theta <= M_PI; theta += angular_resolution)
+        {
+          double x = center_x + r_temp * sin(phi) * cos(theta);
+          double y = center_y + r_temp * sin(phi) * sin(theta);
+          double z = center_z + r_temp * cos(phi);
+          double distance = sqrt(pow(x - center_x, 2) + pow(y - center_y, 2) + pow(z - center_z, 2));
+          points.push_back({ x, y, z, distance });
+        }
+      }
+    }
+    std::sort(points.begin(), points.end(), Point::comparePointsDistance);
+    for (auto& p : points)
+    {
+      points_final_.push_back(p);
+    }
+  }
+  sensor_msgs::PointCloud2 getPointCloud2()
+  {
+    sensor_msgs::PointCloud2 cloud2;
+    sensor_msgs::PointCloud cloud;
+    cloud.header.stamp = ros::Time::now();
+    cloud.header.frame_id = "exchanger";
+    cloud.points.resize(points_final_.size());
+
+    cloud.channels.resize(1);
+    cloud.channels[0].name = "motion";
+    cloud.channels[0].values.resize(points_final_.size());
+
+    for (int i = 0; i < (int)points_final_.size(); ++i)
+    {
+      cloud.points[i].x = points_final_[i].x;
+      cloud.points[i].y = points_final_[i].y;
+      cloud.points[i].z = points_final_[i].z;
+      // cloud.channels[0].values[i] = i;
+    }
+    sensor_msgs::convertPointCloudToPointCloud2(cloud, cloud2);
+    return cloud2;
+  }
+  void rectifyForRPY(double theta, double beta, double k_x, double k_theta, double k_beta)
+  {
+    geometry_msgs::Vector3 rectify;
+    rectify.x = abs(points_final_[0].x) * sin(theta) * k_x;
+    rectify.y = abs(points_final_[0].x) * sin(beta) * k_beta;
+    rectify.z = abs(points_final_[0].x) * sin(theta) * k_theta;
+    ROS_INFO_STREAM(rectify);
+    for (int i = 0; i < (int)points_final_.size(); ++i)
+    {
+      points_final_[i].x += rectify.x;
+      points_final_[i].y += rectify.y;
+      points_final_[i].z -= rectify.z;
+    }
+  }
+  void generateBasicsPoints(double center_x, double center_y, double center_z, double x_length, double y_length,
+                            double z_length, double point_resolution)
+  {
+    points_final_.clear();
+    std::vector<Point> points;
+    double resolution = 1 - point_resolution;
+    for (double x = center_x - x_length / 2; x <= center_x + x_length / 2; x += x_length * resolution)
+    {
+      for (double y = center_y - y_length / 2; y <= center_y + y_length / 2; y += y_length * resolution)
+      {
+        for (double z = center_z - z_length / 2; z <= center_z + z_length / 2; z += z_length * resolution)
+        {
+          double distance = sqrt(pow(x - center_x, 2) + pow(y - center_y, 2) + pow(z - center_z, 2));
+          points.push_back({ x, y, z, distance });
+        }
+      }
+    }
+    std::sort(points.begin(), points.end(), Point::comparePointsDistance);
+    for (auto& p : points)
+    {
+      points_final_.push_back(p);
+    }
+  }
+
+  void cleanPoints()
+  {
+    points_final_.clear();
+  }
+  std::vector<Point> getPoints()
+  {
+    return points_final_;
+  }
+
+  void generateGeometryPoints()
+  {
+    switch (shape_)
+    {
+      case SPHERE:
+        generateSpherePoints(target_x_, target_y_, target_z_, radius_, point_resolution_);
+        break;
+      case BASICS:
+        generateBasicsPoints(target_x_, target_y_, target_z_, x_length_, y_length_, z_length_, point_resolution_);
+        break;
+    }
+  }
+
+  void setValue(Geometry shape, double x, double y, double z, double radius, double point_resolution)
+  {
+    shape_ = shape;
+    target_x_ = x;
+    target_y_ = y;
+    target_z_ = z;
+    radius_ = radius;
+    point_resolution_ = point_resolution;
+  }
+  void setValue(Geometry shape, double x, double y, double z, double x_length, double y_length, double z_length,
+                double point_resolution)
+  {
+    shape_ = shape;
+    target_x_ = x;
+    target_y_ = y;
+    target_z_ = z;
+    x_length_ = x_length;
+    y_length_ = y_length;
+    z_length_ = z_length;
+    point_resolution_ = point_resolution;
+  }
+
+private:
+  Geometry shape_;
+  geometry_msgs::PoseStamped target_;
+  std::vector<Point> points_final_{};
+  double target_x_, target_y_, target_z_, x_length_, y_length_, z_length_, point_resolution_, radius_;
+};
+
+}  // namespace engineer_middleware

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -96,7 +96,7 @@ public:
         sensor_msgs::PointCloud2 point_cloud2 = arm_motion_->getPointCloud2();
         point_cloud_pub_.publish(point_cloud2);
       }
-      std_msgs::Int32 msg = arm_motion_->judgePlanningResult();
+      std_msgs::Int32 msg = arm_motion_->getPlanningResult();
       planning_result_pub_.publish(msg);
     }
     if (hand_motion_)

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -48,7 +48,7 @@ class Step
 public:
   Step(const XmlRpc::XmlRpcValue& step, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
        moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-       ros::Publisher& hand_pub, ros::Publisher& joint7_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
+       ros::Publisher& hand_pub, ros::Publisher& end_effector_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
        ros::Publisher& reversal_pub, ros::Publisher& stone_num_pub, ros::Publisher& planning_result_pub,
        ros::Publisher& point_cloud_pub)
     : planning_result_pub_(planning_result_pub), point_cloud_pub_(point_cloud_pub), arm_group_(arm_group)
@@ -68,8 +68,8 @@ public:
       chassis_motion_ = new ChassisMotion(step["chassis"], chassis_interface);
     if (step.hasMember("hand"))
       hand_motion_ = new HandMotion(step["hand"], hand_pub);
-    if (step.hasMember("joint7"))
-      joint7_motion_ = new JointPositionMotion(step["joint7"], joint7_pub);
+    if (step.hasMember("end_effector"))
+      end_effector_motion_ = new JointPositionMotion(step["end_effector"], end_effector_pub);
     if (step.hasMember("stone_num"))
       stone_num_motion_ = new StoneNumMotion(step["stone_num"], stone_num_pub);
     if (step.hasMember("gimbal"))
@@ -101,8 +101,8 @@ public:
     }
     if (hand_motion_)
       success &= hand_motion_->move();
-    if (joint7_motion_)
-      success &= joint7_motion_->move();
+    if (end_effector_motion_)
+      success &= end_effector_motion_->move();
     if (stone_num_motion_)
       success &= stone_num_motion_->move();
     if (chassis_motion_)
@@ -144,8 +144,8 @@ public:
       success &= arm_motion_->isFinish();
     if (hand_motion_)
       success &= hand_motion_->isFinish();
-    if (joint7_motion_)
-      success &= joint7_motion_->isFinish();
+    if (end_effector_motion_)
+      success &= end_effector_motion_->isFinish();
     if (chassis_motion_)
       success &= chassis_motion_->isFinish();
     if (gimbal_motion_)
@@ -159,8 +159,8 @@ public:
       success &= arm_motion_->checkTimeout(period);
     if (hand_motion_)
       success &= hand_motion_->checkTimeout(period);
-    if (joint7_motion_)
-      success &= joint7_motion_->checkTimeout(period);
+    if (end_effector_motion_)
+      success &= end_effector_motion_->checkTimeout(period);
     if (chassis_motion_)
       success &= chassis_motion_->checkTimeout(period);
     if (gimbal_motion_)
@@ -179,7 +179,7 @@ private:
   ros::Publisher point_cloud_pub_;
   MoveitMotionBase* arm_motion_{};
   HandMotion* hand_motion_{};
-  JointPositionMotion* joint7_motion_{};
+  JointPositionMotion* end_effector_motion_{};
   StoneNumMotion* stone_num_motion_{};
   ChassisMotion* chassis_motion_{};
   GimbalMotion* gimbal_motion_{};

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -60,7 +60,7 @@ public:
       if (step["arm"].hasMember("joints"))
         arm_motion_ = new JointMotion(step["arm"], arm_group);
       else if (step["arm"].hasMember("spacial_shape"))
-        arm_motion_ = new SpaceEEMotion(step["arm"], arm_group, tf);
+        arm_motion_ = new SpaceEeMotion(step["arm"], arm_group, tf);
       else
         arm_motion_ = new EndEffectorMotion(step["arm"], arm_group, tf);
     }

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -48,9 +48,10 @@ class Step
 public:
   Step(const XmlRpc::XmlRpcValue& step, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
        moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-       ros::Publisher& hand_pub, ros::Publisher& card_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
-       ros::Publisher& planning_result_pub)
-    : planning_result_pub_(planning_result_pub), arm_group_(arm_group)
+       ros::Publisher& hand_pub, ros::Publisher& joint7_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
+       ros::Publisher& reversal_pub, ros::Publisher& stone_num_pub, ros::Publisher& planning_result_pub,
+       ros::Publisher& point_cloud_pub)
+    : planning_result_pub_(planning_result_pub), point_cloud_pub_(point_cloud_pub), arm_group_(arm_group)
   {
     ROS_ASSERT(step.hasMember("step"));
     step_name_ = static_cast<std::string>(step["step"]);
@@ -58,6 +59,8 @@ public:
     {
       if (step["arm"].hasMember("joints"))
         arm_motion_ = new JointMotion(step["arm"], arm_group);
+      else if (step["arm"].hasMember("spacial_shape"))
+        arm_motion_ = new SpaceEEMotion(step["arm"], arm_group, tf);
       else
         arm_motion_ = new EndEffectorMotion(step["arm"], arm_group, tf);
     }
@@ -65,12 +68,16 @@ public:
       chassis_motion_ = new ChassisMotion(step["chassis"], chassis_interface);
     if (step.hasMember("hand"))
       hand_motion_ = new HandMotion(step["hand"], hand_pub);
-    if (step.hasMember("card"))
-      card_motion_ = new JointPositionMotion(step["card"], card_pub);
+    if (step.hasMember("joint7"))
+      joint7_motion_ = new JointPositionMotion(step["joint7"], joint7_pub);
+    if (step.hasMember("stone_num"))
+      stone_num_motion_ = new StoneNumMotion(step["stone_num"], stone_num_pub);
     if (step.hasMember("gimbal"))
       gimbal_motion_ = new GimbalMotion(step["gimbal"], gimbal_pub);
     if (step.hasMember("gripper"))
       gpio_motion_ = new GpioMotion(step["gripper"], gpio_pub);
+    if (step.hasMember("reversal"))
+      reversal_motion_ = new ReversalMotion(step["reversal"], reversal_pub);
     if (step.hasMember("scene_name"))
     {
       for (XmlRpc::XmlRpcValue::ValueStruct::const_iterator it = scenes.begin(); it != scenes.end(); ++it)
@@ -84,19 +91,28 @@ public:
     if (arm_motion_)
     {
       success &= arm_motion_->move();
-      std_msgs::Int32 msg = arm_motion_->getPlanningResult();
+      if (!arm_motion_->getPointCloud2().data.empty())
+      {
+        sensor_msgs::PointCloud2 point_cloud2 = arm_motion_->getPointCloud2();
+        point_cloud_pub_.publish(point_cloud2);
+      }
+      std_msgs::Int32 msg = arm_motion_->judgePlanningResult();
       planning_result_pub_.publish(msg);
     }
     if (hand_motion_)
       success &= hand_motion_->move();
-    if (card_motion_)
-      success &= card_motion_->move();
+    if (joint7_motion_)
+      success &= joint7_motion_->move();
+    if (stone_num_motion_)
+      success &= stone_num_motion_->move();
     if (chassis_motion_)
       success &= chassis_motion_->move();
     if (gimbal_motion_)
       success &= gimbal_motion_->move();
     if (gpio_motion_)
       success &= gpio_motion_->move();
+    if (reversal_motion_)
+      success &= reversal_motion_->move();
     if (planning_scene_)
       planning_scene_->add();
     return success;
@@ -116,7 +132,9 @@ public:
     std::map<std::string, moveit_msgs::AttachedCollisionObject> attached_objects =
         planning_scene_interface_.getAttachedObjects();
     for (auto iter = attached_objects.begin(); iter != attached_objects.end(); ++iter)
+    {
       arm_group_.detachObject(iter->first);
+    }
     planning_scene_interface_.removeCollisionObjects(planning_scene_interface_.getKnownObjectNames());
   }
   bool isFinish()
@@ -126,8 +144,8 @@ public:
       success &= arm_motion_->isFinish();
     if (hand_motion_)
       success &= hand_motion_->isFinish();
-    if (card_motion_)
-      success &= card_motion_->isFinish();
+    if (joint7_motion_)
+      success &= joint7_motion_->isFinish();
     if (chassis_motion_)
       success &= chassis_motion_->isFinish();
     if (gimbal_motion_)
@@ -141,8 +159,8 @@ public:
       success &= arm_motion_->checkTimeout(period);
     if (hand_motion_)
       success &= hand_motion_->checkTimeout(period);
-    if (card_motion_)
-      success &= card_motion_->checkTimeout(period);
+    if (joint7_motion_)
+      success &= joint7_motion_->checkTimeout(period);
     if (chassis_motion_)
       success &= chassis_motion_->checkTimeout(period);
     if (gimbal_motion_)
@@ -158,12 +176,15 @@ public:
 private:
   std::string step_name_;
   ros::Publisher planning_result_pub_;
+  ros::Publisher point_cloud_pub_;
   MoveitMotionBase* arm_motion_{};
   HandMotion* hand_motion_{};
-  JointPositionMotion* card_motion_{};
+  JointPositionMotion* joint7_motion_{};
+  StoneNumMotion* stone_num_motion_{};
   ChassisMotion* chassis_motion_{};
   GimbalMotion* gimbal_motion_{};
   GpioMotion* gpio_motion_{};
+  ReversalMotion* reversal_motion_{};
   PlanningScene* planning_scene_{};
   moveit::planning_interface::PlanningSceneInterface planning_scene_interface_;
   moveit::planning_interface::MoveGroupInterface& arm_group_;

--- a/engineer_middleware/include/engineer_middleware/step_queue.h
+++ b/engineer_middleware/include/engineer_middleware/step_queue.h
@@ -53,14 +53,14 @@ class StepQueue
 public:
   StepQueue(const XmlRpc::XmlRpcValue& steps, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
             moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-            ros::Publisher& hand_pub, ros::Publisher& joint7_pub, ros::Publisher& stone_num_pub,
+            ros::Publisher& hand_pub, ros::Publisher& end_effector_pub, ros::Publisher& stone_num_pub,
             ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub, ros::Publisher& reversal_pub,
             ros::Publisher& planning_result_pub, ros::Publisher& point_cloud_pub)
     : chassis_interface_(chassis_interface)
   {
     ROS_ASSERT(steps.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < steps.size(); ++i)
-      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, joint7_pub, stone_num_pub,
+      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, end_effector_pub, stone_num_pub,
                           gimbal_pub, gpio_pub, reversal_pub, planning_result_pub, point_cloud_pub);
   }
   bool run(actionlib::SimpleActionServer<rm_msgs::EngineerAction>& as)

--- a/engineer_middleware/include/engineer_middleware/step_queue.h
+++ b/engineer_middleware/include/engineer_middleware/step_queue.h
@@ -53,14 +53,15 @@ class StepQueue
 public:
   StepQueue(const XmlRpc::XmlRpcValue& steps, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
             moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-            ros::Publisher& hand_pub, ros::Publisher& card_pub, ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub,
-            ros::Publisher& planning_result_pub)
+            ros::Publisher& hand_pub, ros::Publisher& join7_pub, ros::Publisher& stone_num_pub,
+            ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub, ros::Publisher& reversal_pub,
+            ros::Publisher& planning_result_pub, ros::Publisher& point_cloud_pub)
     : chassis_interface_(chassis_interface)
   {
     ROS_ASSERT(steps.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < steps.size(); ++i)
-      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, card_pub, gimbal_pub, gpio_pub,
-                          planning_result_pub);
+      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, join7_pub, stone_num_pub,
+                          gimbal_pub, gpio_pub, reversal_pub, planning_result_pub, point_cloud_pub);
   }
   bool run(actionlib::SimpleActionServer<rm_msgs::EngineerAction>& as)
   {

--- a/engineer_middleware/include/engineer_middleware/step_queue.h
+++ b/engineer_middleware/include/engineer_middleware/step_queue.h
@@ -53,14 +53,14 @@ class StepQueue
 public:
   StepQueue(const XmlRpc::XmlRpcValue& steps, const XmlRpc::XmlRpcValue& scenes, tf2_ros::Buffer& tf,
             moveit::planning_interface::MoveGroupInterface& arm_group, ChassisInterface& chassis_interface,
-            ros::Publisher& hand_pub, ros::Publisher& join7_pub, ros::Publisher& stone_num_pub,
+            ros::Publisher& hand_pub, ros::Publisher& joint7_pub, ros::Publisher& stone_num_pub,
             ros::Publisher& gimbal_pub, ros::Publisher& gpio_pub, ros::Publisher& reversal_pub,
             ros::Publisher& planning_result_pub, ros::Publisher& point_cloud_pub)
     : chassis_interface_(chassis_interface)
   {
     ROS_ASSERT(steps.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < steps.size(); ++i)
-      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, join7_pub, stone_num_pub,
+      queue_.emplace_back(steps[i], scenes, tf, arm_group, chassis_interface, hand_pub, joint7_pub, stone_num_pub,
                           gimbal_pub, gpio_pub, reversal_pub, planning_result_pub, point_cloud_pub);
   }
   bool run(actionlib::SimpleActionServer<rm_msgs::EngineerAction>& as)

--- a/engineer_middleware/src/middleware.cpp
+++ b/engineer_middleware/src/middleware.cpp
@@ -46,7 +46,7 @@ Middleware::Middleware(ros::NodeHandle& nh)
   , arm_group_(moveit::planning_interface::MoveGroupInterface("engineer_arm"))
   , chassis_interface_(nh, tf_)
   , hand_pub_(nh.advertise<std_msgs::Float64>("/controllers/hand_controller/command", 10))
-  , joint7_pub_(nh.advertise<std_msgs::Float64>("/controllers/joint7_controller/command", 10))
+  , end_effector_pub_(nh.advertise<std_msgs::Float64>("/controllers/joint7_controller/command", 10))
   , gimbal_pub_(nh.advertise<rm_msgs::GimbalCmd>("/controllers/gimbal_controller/command", 10))
   , gpio_pub_(nh.advertise<rm_msgs::GpioData>("/controllers/gpio_controller/command", 10))
   , reversal_pub_(nh.advertise<rm_msgs::MultiDofCmd>("/controllers/multi_dof_controller/command", 10))
@@ -68,7 +68,7 @@ Middleware::Middleware(ros::NodeHandle& nh)
     {
       step_queues_.insert(
           std::make_pair(it->first, StepQueue(it->second, scenes_list, tf_, arm_group_, chassis_interface_, hand_pub_,
-                                              joint7_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, stone_num_pub_,
+                                              end_effector_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, stone_num_pub_,
                                               planning_result_pub_, point_cloud_pub_)));
     }
   }

--- a/engineer_middleware/src/middleware.cpp
+++ b/engineer_middleware/src/middleware.cpp
@@ -46,10 +46,13 @@ Middleware::Middleware(ros::NodeHandle& nh)
   , arm_group_(moveit::planning_interface::MoveGroupInterface("engineer_arm"))
   , chassis_interface_(nh, tf_)
   , hand_pub_(nh.advertise<std_msgs::Float64>("/controllers/hand_controller/command", 10))
-  , card_pub_(nh.advertise<std_msgs::Float64>("/controllers/card_controller/command", 10))
+  , joint7_pub_(nh.advertise<std_msgs::Float64>("/controllers/joint7_controller/command", 10))
   , gimbal_pub_(nh.advertise<rm_msgs::GimbalCmd>("/controllers/gimbal_controller/command", 10))
   , gpio_pub_(nh.advertise<rm_msgs::GpioData>("/controllers/gpio_controller/command", 10))
+  , reversal_pub_(nh.advertise<rm_msgs::MultiDofCmd>("/controllers/multi_dof_controller/command", 10))
   , planning_result_pub_(nh.advertise<std_msgs::Int32>("/planning_result", 10))
+  , stone_num_pub_(nh.advertise<std_msgs::String>("/stone_num", 10))
+  , point_cloud_pub_(nh.advertise<sensor_msgs::PointCloud2>("/cloud", 100))
   , tf_listener_(tf_)
   , is_middleware_control_(false)
 {
@@ -65,7 +68,8 @@ Middleware::Middleware(ros::NodeHandle& nh)
     {
       step_queues_.insert(
           std::make_pair(it->first, StepQueue(it->second, scenes_list, tf_, arm_group_, chassis_interface_, hand_pub_,
-                                              card_pub_, gimbal_pub_, gpio_pub_, planning_result_pub_)));
+                                              joint7_pub_, gimbal_pub_, gpio_pub_, reversal_pub_, stone_num_pub_,
+                                              planning_result_pub_, point_cloud_pub_)));
     }
   }
   else


### PR DESCRIPTION
## 主要改动：

- 针对笛卡尔坐标系下的末端Motion解算概率较低的问题，增加了spaceEEMotion，通过增加Points类将发布的点改为球或者点，线，面，立方体。以此达到较高解算成功率的目的。

- ```
  void rectifyForRPY(double theta, double beta, double k_x, double k_theta, double k_beta)
  ```

​		其中这个函数是考虑到兑换框的姿态可能会导致规划的球体完全处于机械臂的可达空间外（比如说pitch仰角很大的时候，往后退0.5m那个点就会飞到天上，所以需要对应的给它一个往下的量）。配套参数文件如下：

```
  EXCHANGE_AUTO:
    - step: "auto exchange"
      arm:
        frame: exchanger
        xyz: [ -0.5, 0., 0. ]
        rpy: [ 0., -1.57, 0. ]
        rpy_rectify: [ 0.01,0.03,0.03 ]
        tolerance_position: 0.2
        tolerance_orientation: 0.2
        spacial_shape: SPHERE
        radius: 0.3
        point_resolution: 0.90
        max_planning_times: 100
        common:
          <<: *SLOWLY_LOW_TIMEOUT
```

#### 次要改动：

- 增加发布矿石数量
- 增加发布点云