### PR TITLE
Use joint7 to replace joint4's function.

### DIFF
--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -280,19 +280,19 @@ public:
       {
         try
         {
-          double roll, pitch, yaw, roll_temp, pitch_temp, yaw_temp;
+          double roll, pitch, yaw, roll_exchange2base, pitch_exchange2base, yaw__exchange2base;
           exchange2base_ = tf_.lookupTransform("base_link", target_.header.frame_id, ros::Time(0));
-          quatToRPY(exchange2base_.transform.rotation, roll_temp, pitch_temp, yaw_temp);
+          quatToRPY(exchange2base_.transform.rotation, roll_exchange2base, pitch_exchange2base, yaw__exchange2base);
           quatToRPY(target_.pose.orientation, roll, pitch, yaw);
-          pitch -= pitch_temp;
+          pitch -= pitch_exchange2base;
           tf2::Quaternion tmp_tf_quaternion;
           tmp_tf_quaternion.setRPY(roll, pitch, yaw);
           geometry_msgs::Quaternion quat_tf = tf2::toMsg(tmp_tf_quaternion);
           target_.pose.orientation = quat_tf;
           quatToRPY(target_.pose.orientation, roll, pitch, yaw);
-          points_.rectifyForRPY(pitch_temp, yaw_temp, k_x_, k_theta_, k_beta_);
-          if (link7_length_)
-            points_.rectifyForLink7(pitch_temp, link7_length_);
+          points_.rectifyForRPY(pitch_exchange2base, yaw__exchange2base, k_x_, k_theta_, k_beta_);
+          if (link7_length_ > 0)
+            points_.rectifyForLink7(pitch_exchange2base, link7_length_);
           target_.pose.position.x = points_.getPoints()[i].x;
           target_.pose.position.y = points_.getPoints()[i].y;
           target_.pose.position.z = points_.getPoints()[i].z;

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -280,7 +280,6 @@ public:
       target_.pose.position.x = points_.getPoints()[i].x;
       target_.pose.position.y = points_.getPoints()[i].y;
       target_.pose.position.z = points_.getPoints()[i].z;
-      target_.pose.orientation = original_quat_msg;
       if (!target_.header.frame_id.empty())
       {
         try

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -238,6 +238,7 @@ public:
     : EndEffectorMotion(motion, interface, tf), tf_(tf)
   {
     radius_ = xmlRpcGetDouble(motion, "radius", 0.1);
+    link7_length_ = xmlRpcGetDouble(motion, "link7_length", 0.);
     if (motion.hasMember("basics_length"))
     {
       ROS_ASSERT(motion["basics_length"].getType() == XmlRpc::XmlRpcValue::TypeArray);
@@ -290,6 +291,8 @@ public:
           double roll, pitch, yaw;
           quatToRPY(exchange2base_.transform.rotation, roll, pitch, yaw);
           points_.rectifyForRPY(pitch, yaw, k_x_, k_theta_, k_beta_);
+          if (link7_length_)
+            points_.rectifyForLink7(pitch_temp, link7_length_);
         }
         catch (tf2::TransformException& ex)
         {
@@ -327,7 +330,7 @@ private:
   geometry_msgs::TransformStamped exchange2base_;
   int max_planning_times_{};
   double radius_, point_resolution_, x_length_, y_length_, z_length_, k_theta_, k_beta_, k_x_, tolerance_position_,
-      tolerance_orientation_;
+      tolerance_orientation_, link7_length_;
 };
 
 class JointMotion : public MoveitMotionBase

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -276,7 +276,6 @@ public:
     int move_times = (int)points_.getPoints().size();
     for (int i = 0; i < move_times && i < max_planning_times_; ++i)
     {
-      tf2::Quaternion original_quat_msg;
       target_.pose.position.x = points_.getPoints()[i].x;
       target_.pose.position.y = points_.getPoints()[i].y;
       target_.pose.position.z = points_.getPoints()[i].z;

--- a/engineer_middleware/include/engineer_middleware/motion.h
+++ b/engineer_middleware/include/engineer_middleware/motion.h
@@ -276,9 +276,6 @@ public:
     int move_times = (int)points_.getPoints().size();
     for (int i = 0; i < move_times && i < max_planning_times_; ++i)
     {
-      target_.pose.position.x = points_.getPoints()[i].x;
-      target_.pose.position.y = points_.getPoints()[i].y;
-      target_.pose.position.z = points_.getPoints()[i].z;
       if (!target_.header.frame_id.empty())
       {
         try
@@ -293,13 +290,15 @@ public:
           geometry_msgs::Quaternion quat_tf = tf2::toMsg(tmp_tf_quaternion);
           target_.pose.orientation = quat_tf;
           quatToRPY(target_.pose.orientation, roll, pitch, yaw);
-
-          tf2::doTransform(target_.pose, final_target_.pose,
-                           tf_.lookupTransform(interface_.getPlanningFrame(), target_.header.frame_id, ros::Time(0)));
-          final_target_.header.frame_id = interface_.getPlanningFrame();
           points_.rectifyForRPY(pitch_temp, yaw_temp, k_x_, k_theta_, k_beta_);
           if (link7_length_)
             points_.rectifyForLink7(pitch_temp, link7_length_);
+          target_.pose.position.x = points_.getPoints()[i].x;
+          target_.pose.position.y = points_.getPoints()[i].y;
+          target_.pose.position.z = points_.getPoints()[i].z;
+          tf2::doTransform(target_.pose, final_target_.pose,
+                           tf_.lookupTransform(interface_.getPlanningFrame(), target_.header.frame_id, ros::Time(0)));
+          final_target_.header.frame_id = interface_.getPlanningFrame();
         }
         catch (tf2::TransformException& ex)
         {

--- a/engineer_middleware/include/engineer_middleware/points.h
+++ b/engineer_middleware/include/engineer_middleware/points.h
@@ -84,7 +84,6 @@ public:
     rectify.x = abs(points_final_[0].x) * sin(theta) * k_x;
     rectify.y = abs(points_final_[0].x) * sin(beta) * k_beta;
     rectify.z = abs(points_final_[0].x) * sin(theta) * k_theta;
-    ROS_INFO_STREAM(rectify);
     for (int i = 0; i < (int)points_final_.size(); ++i)
     {
       points_final_[i].x += rectify.x;

--- a/engineer_middleware/include/engineer_middleware/points.h
+++ b/engineer_middleware/include/engineer_middleware/points.h
@@ -92,6 +92,14 @@ public:
       points_final_[i].z -= rectify.z;
     }
   }
+  void rectifyForLink7(double theta, double link7_length)
+  {
+    for (int i = 0; i < (int)points_final_.size(); ++i)
+    {
+      points_final_[i].x -= link7_length * pow(sin(theta), 2) / (tan(M_PI_2 - theta / 2));
+      points_final_[i].z = link7_length * sin(theta) * cos(theta) / (tan(M_PI_2 - theta / 2));
+    }
+  }
   void generateBasicsPoints(double center_x, double center_y, double center_z, double x_length, double y_length,
                             double z_length, double point_resolution)
   {

--- a/engineer_middleware/include/engineer_middleware/step.h
+++ b/engineer_middleware/include/engineer_middleware/step.h
@@ -69,7 +69,7 @@ public:
     if (step.hasMember("hand"))
       hand_motion_ = new HandMotion(step["hand"], hand_pub);
     if (step.hasMember("end_effector"))
-      end_effector_motion_ = new JointPositionMotion(step["end_effector"], end_effector_pub);
+      end_effector_motion_ = new JointPositionMotion(step["end_effector"], end_effector_pub, tf);
     if (step.hasMember("stone_num"))
       stone_num_motion_ = new StoneNumMotion(step["stone_num"], stone_num_pub);
     if (step.hasMember("gimbal"))


### PR DESCRIPTION
### Adjust for use joint7 to replace joint4
- #### Add rectifyForLink7() for new auto exchanger which use joint7 to replace joint4.
  - The theoretical calculation is like this picture.
- #### change JointPositionMotion
  - let it could get tf infomation